### PR TITLE
added sink nodes algorithm with test and fuzzing harness

### DIFF
--- a/data-structures/graph/fuzz/Cargo.toml
+++ b/data-structures/graph/fuzz/Cargo.toml
@@ -25,3 +25,9 @@ name = "root_nodes"
 path = "fuzz_targets/root_nodes.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "sink_nodes"
+path = "fuzz_targets/sink_nodes.rs"
+test = false
+doc = false

--- a/data-structures/graph/fuzz/README.md
+++ b/data-structures/graph/fuzz/README.md
@@ -15,3 +15,15 @@ and to run the crash cases:
 ```bash
 cargo hfuzz run-debug root_nodes hfuzz_workspace/*/*.fuzz
 ```
+
+### SinkNodes
+
+```bash
+cargo hfuzz run sink_nodes
+```
+
+and to run the crash cases:
+
+```bash
+cargo hfuzz run-debug sink_nodes hfuzz_workspace/*/*.fuzz
+```

--- a/data-structures/graph/fuzz/fuzz_targets/sink_nodes.rs
+++ b/data-structures/graph/fuzz/fuzz_targets/sink_nodes.rs
@@ -1,0 +1,11 @@
+use algebra::prelude::SquareCSR2D;
+use graph::prelude::{GenericGraph, SinkNodes};
+use honggfuzz::fuzz;
+
+fn main() {
+    loop {
+        fuzz!(|csr: GenericGraph<u8, SquareCSR2D<u16, u8>>| {
+            let _sink_nodes = csr.sink_nodes();
+        });
+    }
+}

--- a/data-structures/graph/src/traits/algorithms.rs
+++ b/data-structures/graph/src/traits/algorithms.rs
@@ -8,3 +8,5 @@ pub mod cycle_detection;
 pub use cycle_detection::CycleDetection;
 pub mod root_nodes;
 pub use root_nodes::RootNodes;
+pub mod sink_nodes;
+pub use sink_nodes::SinkNodes;

--- a/data-structures/graph/src/traits/algorithms/sink_nodes.rs
+++ b/data-structures/graph/src/traits/algorithms/sink_nodes.rs
@@ -1,0 +1,36 @@
+//! Submodule providing the `SinkNodes` trait and its blanket
+//! implementation, which provides a method to retrieve the sink nodes of the
+//! graph, which are the set of nodes with no successors.
+
+use algebra::prelude::IntoUsize;
+
+use crate::traits::MonoplexMonopartiteGraph;
+/// Trait providing the `sink_nodes` method, which returns the sink nodes of the
+/// graph. A sink node is a node with no successors.
+pub trait SinkNodes: MonoplexMonopartiteGraph {
+    /// Returns the sink nodes of the graph.
+    fn sink_nodes(&self) -> Vec<Self::NodeId> {
+        let mut visited = vec![false; self.number_of_nodes().into_usize()];
+
+        // Iterate over all nodes and mark the successors of each node as
+        // visited. A node is considered visited if it has a predecessor.
+        for node in self.node_ids() {
+            // Mark the successors of the node as visited.
+            for successor_node_id in self.successors(node) {
+                visited[successor_node_id.into_usize()] = true;
+            }
+        }
+        // Finally, we iterate over all nodes and keep the nodes that have not
+        // been visited. A node is considered visited if it has a predecessor.
+        self.node_ids()
+            .zip(visited.into_iter())
+            .filter_map(
+                |(node, visited)| {
+                    if visited && !self.has_successors(node) { Some(node) } else { None }
+                },
+            )
+            .collect()
+    }
+}
+
+impl<G: MonoplexMonopartiteGraph> SinkNodes for G {}

--- a/data-structures/graph/src/traits/edges.rs
+++ b/data-structures/graph/src/traits/edges.rs
@@ -3,7 +3,7 @@
 
 use algebra::prelude::{
     IntoUsize, MatrixMut, PositiveInteger, SizedRowsSparseMatrix2D, SizedSparseMatrix,
-    SparseMatrix, SparseMatrix2D, SparseMatrixMut, TryFromUsize,
+    SparseMatrix, SparseMatrix2D, SparseMatrixMut, TryFromUsize, Zero
 };
 
 use super::Edge;
@@ -49,6 +49,18 @@ pub trait Edges {
         source: Self::SourceNodeId,
     ) -> <Self::Matrix as SparseMatrix2D>::SparseRow<'_> {
         self.matrix().sparse_row(source)
+    }
+
+    /// Returns whether the given source node has successors.
+    /// 
+    /// # Arguments 
+    /// 
+    /// * `source` - The identifier of the source node.
+    fn has_successors(
+       &self,
+       source: Self::SourceNodeId
+    ) -> bool{
+        self.out_degree(source) >Self::DestinationNodeId::ZERO
     }
 
     /// Returns the outbound degree of the node with the given identifier.

--- a/data-structures/graph/src/traits/monoplex_graph.rs
+++ b/data-structures/graph/src/traits/monoplex_graph.rs
@@ -28,7 +28,17 @@ pub trait MonoplexGraph: super::Graph {
     ) -> <<Self::Edges as Edges>::Matrix as SparseMatrix2D>::SparseRow<'_> {
         self.edges().successors(source_node_id)
     }
-
+    /// Returns whether the given source node has successors.
+    /// 
+    /// # Arguments 
+    /// 
+    /// * `source_node_id` - The identifier of the source node.
+    fn has_successors(
+        &self,
+        source_node_id: <Self::Edges as super::Edges>::SourceNodeId,
+     ) -> bool{
+        self.edges().has_successors(source_node_id)
+     }
     /// Returns the outbound degree of the node with the given identifier.
     ///
     /// # Arguments

--- a/data-structures/graph/tests/test_sink_nodes.rs
+++ b/data-structures/graph/tests/test_sink_nodes.rs
@@ -1,0 +1,67 @@
+//! Test submodule for the `SinkNodes` trait.
+
+use algebra::impls::SquareCSR2D;
+use graph::prelude::Builder;
+use graph::prelude::{
+    DiEdgesBuilder, DiGraph, GenericMonoplexMonopartiteGraphBuilder, GenericVocabularyBuilder,
+    MonopartiteGraph, MonoplexGraph, SinkNodes,
+};
+use graph::traits::EdgesBuilder;
+use graph::traits::MonopartiteGraphBuilder;
+use graph::traits::MonoplexGraphBuilder;
+use graph::traits::VocabularyBuilder;
+use sorted_vec::prelude::SortedVec;
+
+#[test]
+fn test_no_sink_nodes() -> Result<(), Box<dyn std::error::Error>> {
+    let nodes: Vec<usize> = vec![0, 1, 2, 3, 4, 5];
+    let edges: Vec<(usize, usize)> =
+        vec![(0, 1), (1, 2), (1, 3), (2, 1), (2, 3), (3, 4), (4, 5), (5, 0), (5, 1), (5, 3)];
+    let nodes: SortedVec<usize> = GenericVocabularyBuilder::default()
+        .expected_number_of_symbols(nodes.len())
+        .symbols(nodes.into_iter().enumerate())
+        .build()?;
+    let edges: SquareCSR2D<usize, usize> = DiEdgesBuilder::default()
+        .expected_number_of_edges(edges.len())
+        .expected_shape(nodes.len())
+        .edges(edges.into_iter())
+        .build()?;
+    let graph: DiGraph<usize> =
+        GenericMonoplexMonopartiteGraphBuilder::default().nodes(nodes).edges(edges).build()?;
+
+    assert_eq!(graph.number_of_nodes(), 6);
+    assert_eq!(graph.number_of_edges(), 10);
+
+    assert_eq!(graph.sink_nodes(), Vec::new(), "There should be no sink nodes");
+
+    Ok(())
+}
+
+#[test]
+fn test_sink_nodes() -> Result<(), Box<dyn std::error::Error>> {
+    let nodes: Vec<usize> = vec![0, 1, 2, 3, 4, 5];
+    let edges: Vec<(usize, usize)> = vec![(1, 2), (1, 3), (2, 3), (3, 4), (4, 5)];
+    let nodes: SortedVec<usize> = GenericVocabularyBuilder::default()
+        .expected_number_of_symbols(nodes.len())
+        .symbols(nodes.into_iter().enumerate())
+        .build()
+        .unwrap();
+    let edges: SquareCSR2D<usize, usize> = DiEdgesBuilder::default()
+        .expected_number_of_edges(edges.len())
+        .expected_shape(nodes.len())
+        .edges(edges.into_iter())
+        .build()
+        .unwrap();
+    let graph: DiGraph<usize> = GenericMonoplexMonopartiteGraphBuilder::default()
+        .nodes(nodes)
+        .edges(edges)
+        .build()
+        .unwrap();
+
+    assert_eq!(graph.number_of_nodes(), 6);
+    assert_eq!(graph.number_of_edges(), 5);
+
+    assert_eq!(graph.sink_nodes(), vec![5]);
+
+    Ok(())
+}


### PR DESCRIPTION
As a rust excercise I implemented the SinkNodes traits which identifies nodes with no successor but with predecessors. 

I have also added tests and a fuzzing harness for it, and made sure clippy checks passed for the trait.

Ciao